### PR TITLE
Fixe image gsoci.azurecr.io/giantswarm/teleport-tbot:14.1.3 not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Image `gsoci.azurecr.io/giantswarm/teleport-tbot:14.1.3` not found
+
 ## [0.0.1] - 2024-02-22
 
 - added: initial commits for teleport-tbot

--- a/helm/teleport-tbot/values.yaml
+++ b/helm/teleport-tbot/values.yaml
@@ -6,7 +6,7 @@ ciliumNetworkPolicy:
   enabled: false
 
 image:
-  name: "giantswarm/teleport-tbot"
+  name: "giantswarm/teleport"
 registry:
   domain: gsoci.azurecr.io
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29741

### What this PR does / why we need it
- Fixes image `gsoci.azurecr.io/giantswarm/teleport-tbot:14.1.3` not found

In `gazelle/cicddev` cluster:
```
 Warning  Failed            22s (x2 over 37s)      kubelet            Failed to pull image "gsoci.azurecr.io/giantswarm/teleport-tbot:14.1.3": rpc error: code = NotFound desc = failed to pull and unpack image "gsoci.azurecr.io/giantswarm/teleport-tbot:14.1.3": failed to resolve reference "gsoci.azurecr.io/giantswarm/teleport-tbot:14.1.3": gsoci.azurecr.io/giantswarm/teleport-tbot:14.1.3: not found
  Warning  Failed            22s (x2 over 37s)      kubelet            Error: ErrImagePull
  Normal   BackOff           8s (x2 over 36s)       kubelet            Back-off pulling image "gsoci.azurecr.io/giantswarm/teleport-tbot:14.1.3"
  Warning  Failed            8s (x2 over 36s)       kubelet            Error: ImagePullBackOff
```


### Checklist

- [x] Update changelog in CHANGELOG.md.
