### PR TITLE
Duplicate `-tbot` in resource name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Image `gsoci.azurecr.io/giantswarm/teleport-tbot:14.1.3` not found
+- Duplicate `-tbot` in resource name
 
 ## [0.0.1] - 2024-02-22
 

--- a/helm/teleport-tbot/templates/configmap.yaml
+++ b/helm/teleport-tbot/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "resource.default.name" . }}-tbot-config
+  name: {{ include "resource.default.name" . }}-config
   namespace: {{ include "resource.default.namespace"  . }}
   labels:
   {{- include "labels.common" . | nindent 4 }}

--- a/helm/teleport-tbot/templates/deployment.yaml
+++ b/helm/teleport-tbot/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "resource.default.name" . }}-tbot
+  name: {{ include "resource.default.name" . }}
   namespace: {{ include "resource.default.namespace"  . }}
   labels:
   {{- include "labels.common" . | nindent 4 }}
@@ -60,7 +60,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: {{ include "resource.default.name" . }}-tbot-config
+            name: {{ include "resource.default.name" . }}-config
         - name: join-sa-token
           projected:
             sources:

--- a/helm/teleport-tbot/templates/networkpolicy.yaml
+++ b/helm/teleport-tbot/templates/networkpolicy.yaml
@@ -2,7 +2,7 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: {{ include "resource.networkPolicy.name"  . }}-tbot
+  name: {{ include "resource.networkPolicy.name"  . }}
   namespace: {{ include "resource.default.namespace"  . }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
@@ -22,7 +22,7 @@ spec:
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
-  name: {{ include "resource.networkPolicy.name" . }}-tbot
+  name: {{ include "resource.networkPolicy.name" . }}
   namespace: {{ include "resource.default.namespace" . }}
   labels:
     {{- include "labels.common" . | nindent 4 }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29741


### What this PR does / why we need it
- Removes duplicate `-tbot` in resource name, e.g:
```
(teleport.giantswarm.io-gazelle-cicddev)> kubectl get deploy -A | grep tbot
giantswarm                    teleport-tbot-tbot                             0/1     1            0           31m
(teleport.giantswarm.io-gazelle-cicddev)> kubectl get cm -A | grep tbot
giantswarm                    teleport-tbot-chart-values                           1      31m
giantswarm                    teleport-tbot-tbot-config                            1      31m
(teleport.giantswarm.io-gazelle-cicddev)> kubectl get sa -A | grep tbot
giantswarm                    teleport-tbot                                  0         31m
(teleport.giantswarm.io-gazelle-cicddev)> kubectl get netpol -A | grep tbot
giantswarm    teleport-tbot-network-policy-tbot                     app.kubernetes.io/name=tbot                                                                                                                                                                 31m
```

### Checklist

- [x] Update changelog in CHANGELOG.md.
