### PR TITLE
Use release namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Chart to use `.Release.Namespace` namespace
+
 ## [0.0.2] - 2024-02-27
 
 ### Fixed

--- a/helm/teleport-tbot/templates/_resource.tpl
+++ b/helm/teleport-tbot/templates/_resource.tpl
@@ -19,5 +19,5 @@ room for such suffix.
 {{- end -}}
 
 {{- define "resource.default.namespace" -}}
-giantswarm
+{{- .Release.Namespace }}
 {{- end -}}


### PR DESCRIPTION
### What this PR does / why we need it

The chart has `giantswarm` namespace hardcoded, and target namespace `tekton-pipeline` in App CR is no longer used.

```
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  name: teleport-tbot
  namespace: org-team-tinkerers
  labels:
    giantswarm.io/cluster: cicddev
spec:
  catalog: default
  kubeConfig:
    inCluster: false
  name: teleport-tbot
  namespace: tekton-pipelines <--- this
  userConfig:
    configMap:
      name: teleport-tbot-user-values
      namespace: org-team-tinkerers
  # used by renovate
  # repo: giantswarm/teleport-tbot
  version: 0.0.2
```

### Checklist

- [x] Update changelog in CHANGELOG.md.
