### PR TITLE
Rename identity output secret name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Rename identity output secret name
+
 ## [0.0.3] - 2024-02-28
 
 ### Fixed

--- a/helm/teleport-tbot/templates/configmap.yaml
+++ b/helm/teleport-tbot/templates/configmap.yaml
@@ -24,4 +24,4 @@ data:
       - type: identity
         destination:
           type: kubernetes_secret
-          name: identity-output
+          name: teleport-identity-output


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29741

### What this PR does / why we need it
- Adds `teleport` prefix to identity secret name

### Checklist

- [x] Update changelog in CHANGELOG.md.
