### PR TITLE
Use standalone tbot-distroless image v15.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Removed chart tests
+- Use standalone tbot-distroless image v15.1.7
 
 ## [0.0.4] - 2024-02-29
 

--- a/helm/teleport-tbot/values.yaml
+++ b/helm/teleport-tbot/values.yaml
@@ -6,7 +6,7 @@ ciliumNetworkPolicy:
   enabled: false
 
 image:
-  name: "giantswarm/teleport"
+  name: "giantswarm/tbot-distroless"
 registry:
   domain: gsoci.azurecr.io
 
@@ -14,7 +14,7 @@ teleport:
   tokenName: ""
   proxyAddr: test.teleport.giantswarm.io:443
   teleportClusterName: test.teleport.giantswarm.io
-  teleportVersion: 14.1.1
+  teleportVersion: 15.1.7
 
 pod:
   user:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3325

### What this PR does / why we need it

- Use standalone tbot-distroless image v15.1.7

### Checklist

- [x] Update changelog in CHANGELOG.md.
