### PR TITLE
Remove push to app catalog: default, control plane, app collections

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,19 +8,6 @@ workflows:
   build:
     jobs:
       - architect/push-to-app-catalog:
-          name: push-to-default-app-catalog
-          context: architect
-          executor: app-build-suite
-          app_catalog: "default-catalog"
-          app_catalog_test: "default-test-catalog"
-          chart: "teleport-tbot"
-          persist_chart_archive: true
-          filters:
-            # Trigger the job also on git tag.
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-app-catalog:
           name: push-to-giantswarm-app-catalog
           context: architect
           executor: app-build-suite
@@ -29,47 +16,5 @@ workflows:
           chart: "teleport-tbot"
           filters:
             # Trigger the job also on git tag.
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-app-catalog:
-          name: push-teleport-tbot-app-to-control-plane-app-catalog
-          context: architect
-          executor: app-build-suite
-          app_catalog: "control-plane-catalog"
-          app_catalog_test: "control-plane-test-catalog"
-          chart: "teleport-tbot"
-          filters:
-            # Trigger the job also on git tag.
-            tags:
-              only: /^v.*/
-
-      # deploy to aws installations (only tags)
-      - architect/push-to-app-collection:
-          name: push-teleport-tbot-app-to-aws-app-collection
-          context: architect
-          app_name: "teleport-tbot-app"
-          app_namespace: "kube-system"
-          app_collection_repo: "aws-app-collection"
-          requires:
-            - push-teleport-tbot-app-to-control-plane-app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
-      # deploy to azure installations (only tags)
-      - architect/push-to-app-collection:
-          name: push-teleport-tbot-app-to-azure-app-collection
-          context: architect
-          app_name: "teleport-tbot-app"
-          app_namespace: "kube-system"
-          app_collection_repo: "azure-app-collection"
-          requires:
-            - push-teleport-tbot-app-to-control-plane-app-catalog
-          filters:
-            branches:
-              ignore: /.*/
             tags:
               only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove push to app catalog: default, control plane, app collections
+
 ## [0.0.5] - 2024-03-21
 
 ### Changed


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30430

### What this PR does / why we need it

- Remove push to app catalog

✅ giantswarm - tbot deployed on `cicddev/cicdprod` workload cluster.
❌ default - tbot is not part of default apps.
❌ control plane - tbot is not operator, and shouldn't only run on control plane   
❌ app collections - tbot shouldn't be auto-deployed to installations.

### Checklist

- [x] Update changelog in CHANGELOG.md.
