### PR TITLE
Fix cilium network policy and tbot config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Remove push to app catalog: default, control plane, app collections
-- Switched to use recommended `proxy_server` over `auth_server` in tbot configm.
+- Switched to use recommended `proxy_server` over `auth_server` in tbot config.
 
 ## [0.0.5] - 2024-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed cilium network policy, added `cluster` entity to egress rule.
+
 ### Changed
 
 - Remove push to app catalog: default, control plane, app collections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Remove push to app catalog: default, control plane, app collections
+- Switched to use recommended `proxy_server` over `auth_server` in tbot configm.
 
 ## [0.0.5] - 2024-03-21
 

--- a/helm/teleport-tbot/templates/configmap.yaml
+++ b/helm/teleport-tbot/templates/configmap.yaml
@@ -18,7 +18,7 @@ data:
       type: memory
     # ensure this is configured to the address of your Teleport Proxy or
     # Auth Server. Prefer the address of the Teleport Proxy.
-    auth_server: {{ .Values.teleport.proxyAddr }}
+    proxy_server: {{ .Values.teleport.proxyAddr }}
     # outputs will be filled in during the completion of an access guide.
     outputs:
       - type: identity

--- a/helm/teleport-tbot/templates/networkpolicy.yaml
+++ b/helm/teleport-tbot/templates/networkpolicy.yaml
@@ -10,6 +10,7 @@ spec:
   egress:
   - toEntities:
     - kube-apiserver
+    - cluster
     - world
   ingress:
   - toPorts:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30736

### What this PR does / why we need it

- Adjusts the cilium network policy to fix this:
> ERROR: Post "[https://teleport.giantswarm.io:443/v1/webapi/host/credentials](https://teleport.giantswarm.io/v1/webapi/host/credentials)": dial tcp: lookup teleport.giantswarm.io on 172.31.0.10:53: read udp 100.64.17.142:38350->172.31.0.10:53: i/o timeout, net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)

- Switched to recommended `proxy_server` in tbot config.
> WARN [TBOT] We recently introduced the ability to explicitly configure the address of the Teleport Proxy using --proxy-server. We recommend switching to this if you currently provide the address of the Proxy to --auth-server. tbot/tbot.go:311

### Checklist

- [x] Update changelog in CHANGELOG.md.
