### PR TITLE
Add enabled flag to conditionally deploy helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added enabled flag to conditionally deploy helm chart.
+
 ### Fixed
 
 - Fixed potential vulnerability on `devctl` generated `github-workflows`.

--- a/helm/teleport-tbot/templates/configmap.yaml
+++ b/helm/teleport-tbot/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -25,3 +26,4 @@ data:
         destination:
           type: kubernetes_secret
           name: teleport-identity-output
+{{- end }}

--- a/helm/teleport-tbot/templates/deployment.yaml
+++ b/helm/teleport-tbot/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -72,3 +73,4 @@ spec:
                   # `example.teleport.sh` must be replaced with the name of
                   # your Teleport cluster.
                   audience: {{ .Values.teleport.teleportClusterName }}
+{{- end }}

--- a/helm/teleport-tbot/templates/networkpolicy.yaml
+++ b/helm/teleport-tbot/templates/networkpolicy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 {{- if .Values.ciliumNetworkPolicy.enabled }}
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -40,4 +41,5 @@ spec:
   policyTypes:
   - Egress
   - Ingress
+{{- end }}
 {{- end }}

--- a/helm/teleport-tbot/templates/psp.yaml
+++ b/helm/teleport-tbot/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 {{- if not .Values.global.podSecurityStandards.enforced }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -33,4 +34,5 @@ spec:
     - 'projected'
     - 'secret'
     - 'configMap'
+{{- end }}
 {{- end }}

--- a/helm/teleport-tbot/templates/rbac.yaml
+++ b/helm/teleport-tbot/templates/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -111,3 +112,4 @@ roleRef:
   kind: ClusterRole
   name: {{ include "resource.psp.name" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/helm/teleport-tbot/templates/serviceaccount.yaml
+++ b/helm/teleport-tbot/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -5,3 +6,4 @@ metadata:
   namespace: {{ include "resource.default.namespace"  . }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
+{{- end }}

--- a/helm/teleport-tbot/templates/vpa.yaml
+++ b/helm/teleport-tbot/templates/vpa.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 {{- if .Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler" }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -18,4 +19,5 @@ spec:
     name:  {{ include "resource.default.name" . }}
   updatePolicy:
     updateMode: Auto
+{{- end }}
 {{- end }}

--- a/helm/teleport-tbot/values.schema.json
+++ b/helm/teleport-tbot/values.schema.json
@@ -2,6 +2,9 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "enabled": {
+            "type": "boolean"
+        },
         "global": {
             "type": "object",
             "properties": {

--- a/helm/teleport-tbot/values.yaml
+++ b/helm/teleport-tbot/values.yaml
@@ -1,3 +1,5 @@
+enabled: false
+
 global:
   podSecurityStandards:
     enforced: false


### PR DESCRIPTION
### What this PR does / why we need it

- Add enabled flag to conditionally deploy helm chart, disable by default. This feature is essential for selective deployments to MCs through app collection.

### Checklist

- [x] Update changelog in CHANGELOG.md.
