### PR TITLE
Fixes failed parsing config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixes an issue in tbot config file that caused tbot pod to CrashLoopBackOff.
+
 ## [0.0.8] - 2024-08-20
 
 ### Changed

--- a/helm/teleport-tbot/templates/configmap.yaml
+++ b/helm/teleport-tbot/templates/configmap.yaml
@@ -42,8 +42,8 @@ data:
         name: teleport-{{ $value }}-kubeconfig
     {{- end }}
     {{- end }}
-      - type: identity
-        destination:
-          type: kubernetes_secret
-          name: teleport-identity-output
+    - type: identity
+      destination:
+        type: kubernetes_secret
+        name: teleport-identity-output
 {{- end }}


### PR DESCRIPTION
### What this PR does / why we need it

- This PR fixes an issue that causes tbot pod to `CrashLoopBackOff` due to malformed config file because of indentation.
```
kubectl logs teleport-tbot-86b577f894-st8vc -n giantswarm -f

ERROR: loading bot config from path /config/tbot.yaml
	failed parsing config file version: yaml: line 34: did not find expected **key**
```

### Checklist

- [x] Update changelog in CHANGELOG.md.
