### PR TITLE
Use teleport-version v16.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use teleport v16.1.4
+
 ## [0.0.9] - 2024-08-20
 
 ### Fixed

--- a/helm/teleport-tbot/values.yaml
+++ b/helm/teleport-tbot/values.yaml
@@ -16,7 +16,7 @@ teleport:
   tokenName: ""
   proxyAddr: test.teleport.giantswarm.io:443
   teleportClusterName: test.teleport.giantswarm.io
-  teleportVersion: 15.1.7
+  teleportVersion: 16.1.4
 
 pod:
   user:


### PR DESCRIPTION
### What this PR does / why we need it

- This PR bumps the teleport version that fixes an issue where multiple kubernetes_secret output is not reconciled if one of the output fails.

### Checklist

- [x] Update changelog in CHANGELOG.md.
