### PR TITLE
Add label to Kubernetes secret created by teleport-tbot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Label to Kubernetes secret created by teleport-tbot.
+
 ## [0.1.0] - 2024-08-21
 
 ### Changed

--- a/helm/teleport-tbot/templates/configmap.yaml
+++ b/helm/teleport-tbot/templates/configmap.yaml
@@ -40,10 +40,14 @@ data:
       destination:
         type: kubernetes_secret
         name: teleport-{{ $value }}-kubeconfig
+        labels:
+          app.kubernetes.io/managed-by: teleport-tbot
     {{- end }}
     {{- end }}
     - type: identity
       destination:
         type: kubernetes_secret
         name: teleport-identity-output
+        labels:
+          app.kubernetes.io/managed-by: teleport-tbot        
 {{- end }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30767

### What this PR does / why we need it

- Adds label to Kubernetes secret created by teleport-tbot.

### Checklist

- [x] Update changelog in CHANGELOG.md.
