### PR TITLE
Add cronjob to cleanup leftover kubeconfigs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add cronjob to cleanup leftover teleport-kubeconfigs for deleted clusters.
+
 ## [0.1.1] - 2024-08-21
 
 ### Added

--- a/helm/teleport-tbot/templates/cronjob.tpl
+++ b/helm/teleport-tbot/templates/cronjob.tpl
@@ -41,7 +41,7 @@ spec:
                 cluster_name=$(kubectl get clusters.cluster.x-k8s.io -l cluster.x-k8s.io/cluster-name="$cluster_id" -A -o name)
                 if [ -z "$cluster_name" ]; then
                   echo "Cluster ${cluster_id} doesn't exist, deleting the secret."
-                  {set -x; kubectl delete secret "$secret" -n "$NAMESPACE"; set +x}
+                  kubectl delete secret "$secret" -n "$NAMESPACE"
                 else
                   echo "Cluster $cluster_id exist, skipping secret."
                 fi

--- a/helm/teleport-tbot/templates/cronjob.tpl
+++ b/helm/teleport-tbot/templates/cronjob.tpl
@@ -41,9 +41,9 @@ spec:
                 cluster_name=$(kubectl get clusters.cluster.x-k8s.io -l cluster.x-k8s.io/cluster-name="$cluster_id" -A -o name)
                 if [ -z "$cluster_name" ]; then
                   echo "Cluster ${cluster_id} doesn't exist, deleting the secret."
-                  echo kubectl delete secret $secret -n $NAMESPACE
+                  {set -x; kubectl delete secret "$secret" -n "$NAMESPACE"; set +x}
                 else
-                  echo "Cluster ${cluster_id} exist, skipping secret."
+                  echo "Cluster $cluster_id exist, skipping secret."
                 fi
               done
 {{- end }}

--- a/helm/teleport-tbot/templates/cronjob.tpl
+++ b/helm/teleport-tbot/templates/cronjob.tpl
@@ -1,0 +1,46 @@
+{{- if .Values.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: clean-{{ include "resource.default.name" . }}-kubeconfigs
+  namespace: {{ include "resource.default.namespace"  . }}
+  labels:
+  {{- include "labels.common" . | nindent 4 }}
+spec:
+  schedule: "0 * * * *"  # Runs every hour
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: {{ include "resource.default.name"  . }}
+          securityContext:
+            runAsUser: {{ .Values.pod.user.id }}
+            runAsGroup: {{ .Values.pod.group.id }}
+            {{- with .Values.podSecurityContext }}
+              {{- . | toYaml | nindent 12 }}
+            {{- end }}
+          restartPolicy: OnFailure
+          containers:
+          - name: cleanup-teleport-kubeconfigs
+            image: {{ .Values.registry.domain }}/{{ .Values.cronjob.image.name }}:{{ .Values.cronjob.image.tag }}
+            securityContext:
+            {{- with .Values.containerSecurityContext }}
+              {{- . | toYaml | nindent 14 }}
+            {{- end }}
+            command:
+            - /bin/sh
+            - -c
+            - |
+              NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+              secrets=$(kubectl get secrets -n "$NAMESPACE" -l app.kubernetes.io/managed-by=teleport-tbot -o custom-columns=:metadata.name --no-headers)
+              for secret in $secrets; do
+                cluster_id=$(echo "$secret" | sed 's/^teleport-\(.*\)-kubeconfig$/\1/')
+                cluster_name=$(kubectl get clusters.cluster.x-k8s.io -l cluster.x-k8s.io/cluster-name="$cluster_id" -A -o name)
+                if [ -z "$cluster_name" ]; then
+                  echo "Cluster ${cluster_id} doesn't exist, deleting the secret."
+                  echo kubectl delete secret $secret -n $NAMESPACE
+                else
+                  echo "Cluster ${cluster_id} exist, skipping secret."
+                fi
+              done
+{{- end }}

--- a/helm/teleport-tbot/templates/cronjob.tpl
+++ b/helm/teleport-tbot/templates/cronjob.tpl
@@ -11,6 +11,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: tbot
         spec:
           serviceAccountName: {{ include "resource.default.name"  . }}
           securityContext:

--- a/helm/teleport-tbot/values.schema.json
+++ b/helm/teleport-tbot/values.schema.json
@@ -37,6 +37,22 @@
                 }
             }
         },
+        "cronjob": {
+            "type" : "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "teleport": {
             "type": "object",
             "properties": {

--- a/helm/teleport-tbot/values.yaml
+++ b/helm/teleport-tbot/values.yaml
@@ -12,6 +12,11 @@ image:
 registry:
   domain: gsoci.azurecr.io
 
+cronjob:
+  image:
+    name: "giantswarm/docker-kubectl"
+    tag: "1.31.0"
+
 teleport:
   tokenName: ""
   proxyAddr: test.teleport.giantswarm.io:443


### PR DESCRIPTION
### What this PR does / why we need it

- Add cronjob to cleanup leftover teleport-kubeconfigs for deleted clusters.

### Checklist

- [x] Update changelog in CHANGELOG.md.
