### PR TITLE
Remove duplicate default identity output entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove duplicate default identity output entry
+
 ## [0.2.0] - 2024-08-22
 
 ### Added

--- a/helm/teleport-tbot/templates/configmap.yaml
+++ b/helm/teleport-tbot/templates/configmap.yaml
@@ -30,6 +30,8 @@ data:
       destination:
         type: kubernetes_secret
         name: {{ .Values.defaultOutput.secretName }}
+        labels:
+          app.kubernetes.io/managed-by: teleport-tbot
     {{- end }}
     {{- end }}
     {{- if .Values.outputs }}
@@ -44,10 +46,4 @@ data:
           app.kubernetes.io/managed-by: teleport-tbot
     {{- end }}
     {{- end }}
-    - type: identity
-      destination:
-        type: kubernetes_secret
-        name: teleport-identity-output
-        labels:
-          app.kubernetes.io/managed-by: teleport-tbot        
 {{- end }}


### PR DESCRIPTION
### What this PR does / why we need it

- Removes duplicate default identity output entry.

### Checklist

- [x] Update changelog in CHANGELOG.md.
