### PR TITLE
Support toggling cronjob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Supports enabling cronjob by setting `cronjob.enabled`. Disabled by default.
+
 ### Removed
 
 - Remove duplicate default identity output entry

--- a/helm/teleport-tbot/templates/cronjob.tpl
+++ b/helm/teleport-tbot/templates/cronjob.tpl
@@ -1,4 +1,4 @@
-{{- if .Values.enabled }}
+{{- if and .Values.enabled .Values.cronjob.enabled }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/helm/teleport-tbot/values.schema.json
+++ b/helm/teleport-tbot/values.schema.json
@@ -40,6 +40,9 @@
         "cronjob": {
             "type" : "object",
             "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
                 "image": {
                     "type": "object",
                     "properties": {

--- a/helm/teleport-tbot/values.yaml
+++ b/helm/teleport-tbot/values.yaml
@@ -13,6 +13,7 @@ registry:
   domain: gsoci.azurecr.io
 
 cronjob:
+  enabled: false
   image:
     name: "giantswarm/docker-kubectl"
     tag: "1.31.0"


### PR DESCRIPTION
### What this PR does / why we need it

- Ability to enable cronjob. Disabled by default.

For e.g, cronjob is not needed when teleport-tbot runs on CICD cluster, e.g: `cicddev` and `cicdprod`. In these clusters, teleport-tbot will not be generating kubeconfigs, as such cleanup cronjob is not needed there.

### Checklist

- [x] Update changelog in CHANGELOG.md.
